### PR TITLE
fix: label icon-only controls

### DIFF
--- a/src/components/group-toolbar.tsx
+++ b/src/components/group-toolbar.tsx
@@ -52,15 +52,22 @@ export function GroupToolbar({
         size="sm"
         className="h-7 w-7 shrink-0 p-0"
         onClick={onCreateGroup}
+        aria-label="Create a new custom group"
         title="Create a new custom group"
       >
-        <Plus className="h-3.5 w-3.5" />
+        <Plus className="h-3.5 w-3.5" aria-hidden />
       </Button>
 
       <Popover>
         <PopoverTrigger asChild>
-          <Button variant="outline" size="sm" className="h-7 w-7 shrink-0 p-0" title="Grouping settings">
-            <Settings className="h-3.5 w-3.5" />
+          <Button
+            variant="outline"
+            size="sm"
+            className="h-7 w-7 shrink-0 p-0"
+            aria-label="Grouping settings"
+            title="Grouping settings"
+          >
+            <Settings className="h-3.5 w-3.5" aria-hidden />
           </Button>
         </PopoverTrigger>
         <PopoverContent className="w-80" align="end">

--- a/src/components/tab-group-card.tsx
+++ b/src/components/tab-group-card.tsx
@@ -149,9 +149,10 @@ export function TabGroupCard({
               size="icon"
               className={groupActionBtn}
               onClick={() => onConvertToCustom(group)}
+              aria-label={`Save ${displayName} as custom group`}
               title="Save as custom group"
             >
-              <Bookmark className="h-3.5 w-3.5" />
+              <Bookmark className="h-3.5 w-3.5" aria-hidden />
             </Button>
           )}
           {isCustomGroup && onToggleImportant && (
@@ -160,6 +161,11 @@ export function TabGroupCard({
               size="icon"
               className={groupActionBtn}
               onClick={() => onToggleImportant(group.id)}
+              aria-label={
+                group.isImportant
+                  ? `Remove important mark from ${displayName}`
+                  : `Mark ${displayName} as important`
+              }
               title={group.isImportant ? 'Remove important mark' : 'Mark as important'}
             >
               <Shield
@@ -167,6 +173,7 @@ export function TabGroupCard({
                   'h-3.5 w-3.5',
                   group.isImportant && 'fill-amber-500 text-amber-500'
                 )}
+                aria-hidden
               />
             </Button>
           )}
@@ -176,30 +183,39 @@ export function TabGroupCard({
               size="icon"
               className={groupActionBtn}
               onClick={() => onEditGroup(group.id)}
+              aria-label={`Edit ${displayName}`}
               title="Edit group"
             >
-              <Edit2 className="h-3.5 w-3.5" />
+              <Edit2 className="h-3.5 w-3.5" aria-hidden />
             </Button>
           )}
           {isCustomGroup && onDeleteGroup && (
             <Button
               variant="ghost"
               size="icon"
-              className={cn(groupActionBtn, 'text-destructive hover:text-destructive')}
+              className={cn(
+                groupActionBtn,
+                'text-destructive hover:text-destructive'
+              )}
               onClick={() => onDeleteGroup(group.id)}
+              aria-label={`Delete ${displayName}`}
               title="Delete group"
             >
-              <Trash2 className="h-3.5 w-3.5" />
+              <Trash2 className="h-3.5 w-3.5" aria-hidden />
             </Button>
           )}
           <Button
             variant="ghost"
             size="icon"
-            className={cn(groupActionBtn, 'text-destructive hover:bg-destructive/10 hover:text-destructive')}
+            className={cn(
+              groupActionBtn,
+              'text-destructive hover:bg-destructive/10 hover:text-destructive'
+            )}
             onClick={handleCloseAll}
+            aria-label={`Close all tabs in ${displayName}`}
             title="Close all tabs"
           >
-            <X className="h-3.5 w-3.5" />
+            <X className="h-3.5 w-3.5" aria-hidden />
           </Button>
         </div>
       </CardHeader>

--- a/src/components/tab-item.tsx
+++ b/src/components/tab-item.tsx
@@ -35,7 +35,6 @@ export function TabItem({
   onClick,
   showActivity = true,
   customGroups = [],
-  currentGroupId: _currentGroupId,
   onAddToGroup,
   onRemoveFromGroup,
   onDuplicate,
@@ -131,8 +130,10 @@ export function TabItem({
               onClick={(e) => {
                 e.stopPropagation();
               }}
+              aria-label={`Manage ${tab.title}`}
+              title="Manage tab"
             >
-              <MoreVertical className="h-3 w-3" />
+              <MoreVertical className="h-3 w-3" aria-hidden />
             </Button>
           </PopoverTrigger>
           <PopoverContent className="w-48 p-1" align="end">
@@ -252,8 +253,10 @@ export function TabItem({
           e.stopPropagation();
           onClose(tab.id);
         }}
+        aria-label={`Close ${tab.title}`}
+        title="Close tab"
       >
-        <X className="h-3 w-3" />
+        <X className="h-3 w-3" aria-hidden />
       </Button>
     </div>
   );

--- a/src/components/theme-switcher.tsx
+++ b/src/components/theme-switcher.tsx
@@ -43,6 +43,7 @@ export function ThemeSwitcher() {
         size="icon"
         className="h-7 w-7"
         aria-label="Toggle dark mode"
+        title="Toggle dark mode"
         onClick={toggleTheme}
       >
         <span className="relative flex size-3.5 items-center justify-center">
@@ -75,8 +76,9 @@ export function ThemeSwitcher() {
             size="icon"
             className="h-7 w-7"
             aria-label="Theme preset"
+            title="Theme preset"
           >
-            <Palette className="size-3.5" />
+            <Palette className="size-3.5" aria-hidden />
           </Button>
         </DropdownMenuTrigger>
         <DropdownMenuContent align="end" className="w-44">


### PR DESCRIPTION
## Summary

Add accessible names and hover titles to icon-only controls in tab items, group cards, the theme switcher, and the group toolbar.

## Related issue

Fixes #17

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor / chore

## Test plan

- [ ] `pnpm lint` passes
- [x] `pnpm build` succeeds
- [ ] Loaded extension from `dist/` in Chrome
- [ ] Tested in Chrome (version: ___)

Note: `pnpm lint` currently fails before linting because ESLint 9 does not load the repo's legacy `.eslintrc.cjs` without compatibility mode. I validated the changed files with `ESLINT_USE_FLAT_CONFIG=false ./node_modules/.bin/eslint src/components/tab-item.tsx src/components/tab-group-card.tsx src/components/theme-switcher.tsx src/components/group-toolbar.tsx --ext ts,tsx --report-unused-disable-directives --max-warnings 0`.

**Manual testing steps:**

1. N/A (not run locally in Chrome).
2. N/A

## Screenshots / recording

N/A

## Checklist

- [x] My change is focused — no unrelated refactors
- [ ] I tested in the side panel (not just in isolation)
- [x] New Chrome permissions are justified and documented (if applicable)
