### PR TITLE
feat: expand KNOWN_DOMAINS with 35 popular sites

### DIFF
--- a/src/lib/tab-utils.ts
+++ b/src/lib/tab-utils.ts
@@ -8,6 +8,7 @@ import {
 } from '@/types/tab';
 
 const KNOWN_DOMAINS: DomainMapping = {
+  // Major platforms
   'google.com': 'Google',
   'youtube.com': 'YouTube',
   'github.com': 'GitHub',
@@ -18,6 +19,48 @@ const KNOWN_DOMAINS: DomainMapping = {
   'reddit.com': 'Reddit',
   'amazon.com': 'Amazon',
   'netflix.com': 'Netflix',
+  // Productivity & collaboration
+  'notion.so': 'Notion',
+  'figma.com': 'Figma',
+  'slack.com': 'Slack',
+  'discord.com': 'Discord',
+  'linear.app': 'Linear',
+  'trello.com': 'Trello',
+  'asana.com': 'Asana',
+  'clickup.com': 'ClickUp',
+  'miro.com': 'Miro',
+  'canva.com': 'Canva',
+  // Dev tools
+  'gitlab.com': 'GitLab',
+  'bitbucket.org': 'Bitbucket',
+  'vercel.com': 'Vercel',
+  'netlify.com': 'Netlify',
+  'heroku.com': 'Heroku',
+  'replit.com': 'Replit',
+  'codepen.io': 'CodePen',
+  'codesandbox.io': 'CodeSandbox',
+  // Communication
+  'zoom.us': 'Zoom',
+  'teams.microsoft.com': 'Microsoft Teams',
+  'meet.google.com': 'Google Meet',
+  'web.whatsapp.com': 'WhatsApp',
+  'telegram.org': 'Telegram',
+  // Media & content
+  'medium.com': 'Medium',
+  'dev.to': 'DEV Community',
+  'twitch.tv': 'Twitch',
+  'spotify.com': 'Spotify',
+  'pinterest.com': 'Pinterest',
+  'instagram.com': 'Instagram',
+  // Cloud & storage
+  'drive.google.com': 'Google Drive',
+  'dropbox.com': 'Dropbox',
+  'onedrive.live.com': 'OneDrive',
+  'icloud.com': 'iCloud',
+  // AI tools
+  'chat.openai.com': 'ChatGPT',
+  'claude.ai': 'Claude',
+  'huggingface.co': 'Hugging Face',
 };
 
 export function prettifyDomain(domain: string): string {


### PR DESCRIPTION
## What

Adds 35 popular domains to the `KNOWN_DOMAINS` map in `tab-utils.ts`, organized by category.

## Domains added

**Productivity & collaboration:** Notion, Figma, Slack, Discord, Linear, Trello, Asana, ClickUp, Miro, Canva

**Dev tools:** GitLab, Bitbucket, Vercel, Netlify, Heroku, Replit, CodePen, CodeSandbox

**Communication:** Zoom, Microsoft Teams, Google Meet, WhatsApp, Telegram

**Media & content:** Medium, DEV Community, Twitch, Spotify, Pinterest, Instagram

**Cloud & storage:** Google Drive, Dropbox, OneDrive, iCloud

**AI tools:** ChatGPT, Claude, Hugging Face

## Why

The original map only covered 10 major platforms. These are among the most commonly visited sites for developers and knowledge workers — the exact audience for Tab Wise. Having proper display names instead of the fallback prettification (e.g. "Notion" instead of "Notion") makes the grouping feel more polished.

Closes #18