### PR TITLE
fix: Auth Hardening for tab-wise

### DIFF
--- a/src/background.ts
+++ b/src/background.ts
@@ -145,7 +145,13 @@ chrome.windows.onFocusChanged.addListener(async (windowId) => {
 });
 
 // Handle messages from side panel
-chrome.runtime.onMessage.addListener((message: BackgroundMessage, _sender, sendResponse) => {
+chrome.runtime.onMessage.addListener((message: BackgroundMessage, sender, sendResponse) => {
+  // Security fix: Validate the sender of the message to ensure it originates from the extension's own trusted UI
+  // and not from a content script injected into an untrusted web page or an external source.
+  if (sender.id !== chrome.runtime.id || sender.tab) {
+    sendResponse({ success: false, error: 'Unauthorized sender' });
+    return false;
+  }
   handleMessage(message).then(sendResponse);
   return true; // Keep channel open for async response
 });


### PR DESCRIPTION
Hey there! 👋

I was reviewing the codebase and noticed a potential security issue that I thought I'd flag and fix.

## What I found

- **[HIGH] auth_bypass** in `src/background.ts`: The background script processes sensitive messages (like closing or switching tabs) without validating the message sende

## What I changed

The fix is minimal and targeted — I added proper validation/sanitization where user-controlled or untrusted data enters sensitive operations. No changes to existing functionality or public APIs.

## Testing

Ran the existing test suite locally, everything passes. The change is backward-compatible.

Happy to discuss if you have questions!

Relates to: https://github.com/Sid-1819/tab-wise/issues/30

---
💛 If this fix helps, donations are appreciated (ETH/ERC-20): `0x1478f1BDEACc7b434b4405350A15993cDcddc79F` ([Etherscan](https://etherscan.io/address/0x1478f1BDEACc7b434b4405350A15993cDcddc79F))