### PR TITLE
docs: add Troubleshooting & FAQ section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,6 +174,31 @@ Our vision for the next 6 months focuses on stability, performance, and advanced
 - **Feature requests:** [GitHub Discussions](https://github.com/Sid-1819/tab-wise/discussions)
 - **Security issues:** [Security policy](./SECURITY.md) — please report privately, not via public issues
 
+---
+
+## Troubleshooting & FAQ
+
+### For Developers
+
+**Why can't I use `npm install`?**  
+This project enforces `pnpm`. Install it first with `npm install -g pnpm`, then run `pnpm install`.
+
+**Hot reload isn't reflecting my changes?**  
+Hot reload doesn't apply automatically for extensions. After making changes, go to `chrome://extensions` and click the reload button on the extension manually.
+
+**Which folder do I load in Chrome?**  
+Load the `dist/` folder — not the project root. Go to `chrome://extensions` → Enable Developer Mode → Load Unpacked → select `dist/`.
+
+### For Users
+
+**The side panel isn't opening?**  
+Side panels require Chrome 114 or newer. Update your Chrome browser and try again.
+
+**Some tabs aren't being restored?**  
+Chrome blocks access to `chrome://` and extension URLs for security reasons. These tabs cannot be restored — this is a Chrome limitation, not a bug.
+
+---
+
 ## Community
 
 - [Contributing](./CONTRIBUTING.md)


### PR DESCRIPTION
## Summary
Added a Troubleshooting & FAQ section to README.md covering common 
questions for both developers and users of the extension.

## Related issue
Fixes #64

## Type of change
- [ ] Bug fix
- [ ] New feature
- [x] Documentation update
- [ ] Refactor / chore

## Test plan
- [ ] `pnpm lint` passes
- [ ] `pnpm build` succeeds
- [ ] Loaded extension from `dist/` in Chrome
- [ ] Tested in Chrome (version: ___)

**Manual testing steps:**
1. Open README.md and scroll to the Troubleshooting & FAQ section
2. Verify it appears between Support and Community sections

## Screenshots / recording
N/A — documentation only change

## Checklist
- [x] My change is focused — no unrelated refactors
- [ ] I tested in the side panel (not just in isolation)
- [ ] New Chrome permissions are justified and documented (if applicable)